### PR TITLE
Fixing missing marketProjection filter when calling listMarketCatalogue ...

### DIFF
--- a/java/ng/src/main/java/com/betfair/aping/api/ApiNgJsonRpcOperations.java
+++ b/java/ng/src/main/java/com/betfair/aping/api/ApiNgJsonRpcOperations.java
@@ -72,6 +72,7 @@ public class ApiNgJsonRpcOperations extends ApiNgOperations{
         params.put(FILTER, filter);
         params.put(SORT, sort);
         params.put(MAX_RESULT, maxResult);
+        params.put(MARKET_PROJECTION, marketProjection);
         String result = getInstance().makeRequest(ApiNgOperation.LISTMARKETCATALOGUE.getOperationName(), params, appKey, ssoId);
         if(ApiNGDemo.isDebug())
             System.out.println("\nResponse: "+result);

--- a/java/ng/src/main/java/com/betfair/aping/api/ApiNgOperations.java
+++ b/java/ng/src/main/java/com/betfair/aping/api/ApiNgOperations.java
@@ -13,9 +13,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-
 public abstract class ApiNgOperations {
-	protected final String FILTER = "filter";
+
+    protected final String FILTER = "filter";
     protected final String LOCALE = "locale";
     protected final String SORT = "sort";
     protected final String MAX_RESULT = "maxResults";
@@ -24,18 +24,18 @@ public abstract class ApiNgOperations {
     protected final String INSTRUCTIONS = "instructions";
     protected final String CUSTOMER_REF = "customerRef";
     protected final String locale = Locale.getDefault().toString();
+    protected final String MARKET_PROJECTION = "marketProjection";
 
-	public abstract List<EventTypeResult> listEventTypes(MarketFilter filter, String appKey, String ssoId) throws APINGException;
+    public abstract List<EventTypeResult> listEventTypes(MarketFilter filter, String appKey, String ssoId) throws APINGException;
 
-	public abstract List<MarketBook> listMarketBook(List<String> marketIds, PriceProjection priceProjection, OrderProjection orderProjection,
-						MatchProjection matchProjection, String currencyCode, String appKey, String ssoId) throws APINGException;
+    public abstract List<MarketBook> listMarketBook(List<String> marketIds, PriceProjection priceProjection, OrderProjection orderProjection,
+            MatchProjection matchProjection, String currencyCode, String appKey, String ssoId) throws APINGException;
 
     public abstract List<MarketCatalogue> listMarketCatalogue(MarketFilter filter, Set<MarketProjection> marketProjection,
-        MarketSort sort, String maxResult, String appKey, String ssoId) throws APINGException;
+            MarketSort sort, String maxResult, String appKey, String ssoId) throws APINGException;
 
-	public abstract PlaceExecutionReport placeOrders(String marketId, List<PlaceInstruction> instructions, String customerRef , String appKey, String ssoId) throws APINGException;
+    public abstract PlaceExecutionReport placeOrders(String marketId, List<PlaceInstruction> instructions, String customerRef, String appKey, String ssoId) throws APINGException;
 
-    protected abstract String makeRequest(String operation, Map<String, Object> params, String appKey, String ssoToken) throws  APINGException;
+    protected abstract String makeRequest(String operation, Map<String, Object> params, String appKey, String ssoToken) throws APINGException;
 
 }
-

--- a/java/ng/src/main/java/com/betfair/aping/api/ApiNgRescriptOperations.java
+++ b/java/ng/src/main/java/com/betfair/aping/api/ApiNgRescriptOperations.java
@@ -62,6 +62,7 @@ public class ApiNgRescriptOperations extends ApiNgOperations {
         params.put(FILTER, filter);
         params.put(SORT, sort);
         params.put(MAX_RESULT, maxResult);
+        params.put(MARKET_PROJECTION, marketProjection);
         String result = getInstance().makeRequest(ApiNgOperation.LISTMARKETCATALOGUE.getOperationName(), params, appKey, ssoId);
         if(ApiNGDemo.isDebug())
             System.out.println("\nResponse: "+result);


### PR DESCRIPTION
The Java code sample's API doesn't use the marketProjection parameter in the request for listMarketCatalogue() , so no Runners, Descriptions, etc.. was returned from the gateway for the "rescript" or JSON requests.

These 3 lines fix the issue.
