### PR TITLE
Addition to closed issue #2 (The same fix for Rescript)

### DIFF
--- a/java/ng/src/main/java/com/betfair/aping/api/ApiNgRescriptOperations.java
+++ b/java/ng/src/main/java/com/betfair/aping/api/ApiNgRescriptOperations.java
@@ -65,6 +65,7 @@ public class ApiNgRescriptOperations extends ApiNgOperations {
         params.put(FILTER, filter);
         params.put(SORT, sort);
         params.put(MAX_RESULT, maxResult);
+        params.put(MARKET_PROJECTION, marketProjection);
         String result = getInstance().makeRequest(ApiNgOperation.LISTMARKETCATALOGUE.getOperationName(), params, appKey, ssoId);
         if(ApiNGDemo.isDebug())
             System.out.println("\nResponse: "+result);


### PR DESCRIPTION
Missing parameter for listMarketCatalogue was added by commit ee60c54921f18f4d1d7649dd335c3a671e7fab5c  but only to ApiNgJsonRpcOperations.  In ApiNgRescriptOperations it is still missing.
