### PR TITLE
fix to swallowed exception message

### DIFF
--- a/python/ApiNgDemoJsonRpc.py
+++ b/python/ApiNgDemoJsonRpc.py
@@ -150,7 +150,7 @@ def placeFailingBet(marketId, selectionId):
             """
             print 'Reason for Place order failure is ' + place_order_result['instructionReports'][0]['errorCode']
         except:
-            print  'Exception from API-NG' + str(place_order_result['error'])
+            print  'Exception from API-NG' + str(place_order_load['error'])
         """
         print place_order_Response
         """


### PR DESCRIPTION
In the `except` block the variable `place_order_result` does not get set if the key `result` is not found in the `place_order_load` dictionary (i.e. the scenario when no result is obtained from the http request). As such, the error message is not in the `place_order_result` dictionary.